### PR TITLE
removed prepending slash from stylesheet path

### DIFF
--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -57,7 +57,7 @@ export default class HTMLPrinter implements Generatable<DMMFDocument> {
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    ${this.getHead("/styles/main.css")}
+    ${this.getHead("styles/main.css")}
   </head>
   <body class="bg-gray-200">
     <div class="flex min-h-screen">


### PR DESCRIPTION
Great work @pantharshit00, these docs will make the developer experience so much nicer 🙌 

A super small change to remove the prepending slash from the stylesheet path, that causes the page to display without styles.