### PR TITLE
fix: implement support for union types

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,27 +30,27 @@
     "url": "https://github.com/pantharshit00/prisma-docs-generator/issues"
   },
   "dependencies": {
-    "@prisma/generator-helper": "^2.6.2",
-    "@prisma/sdk": "^2.6.2",
+    "@prisma/generator-helper": "^2.8.0",
+    "@prisma/sdk": "^2.8.0",
     "express": "^4.17.1",
     "indent-string": "^4.0.0",
-    "kleur": "^4.1.1",
+    "kleur": "^4.1.3",
     "meow": "^7.1.1",
     "pluralize": "^8.0.0",
     "prismjs": "^1.21.0"
   },
   "devDependencies": {
-    "@prisma/cli": "^2.6.2",
-    "@prisma/client": "^2.6.2",
+    "@prisma/cli": "^2.8.0",
+    "@prisma/client": "^2.8.0",
     "@types/express": "4.17.7",
-    "@types/jest": "^26.0.13",
-    "@types/node": "^14.10.1",
+    "@types/jest": "^26.0.14",
+    "@types/node": "^14.11.2",
     "@types/prismjs": "^1.16.1",
     "jest": "^26.4.2",
-    "prettier": "^2.1.1",
-    "ts-jest": "^26.3.0",
+    "prettier": "^2.1.2",
+    "ts-jest": "^26.4.1",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.0.3"
   },
   "scripts": {
     "start": "ts-node main.ts",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["atomicNumberOperations"]
 }
 
 generator docs {

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -21,6 +21,7 @@ const primitiveTypes = [
   'Float',
   'Json',
   'DateTime',
+  'Null',
 ];
 
 export function isScalarType(type: string): boolean {

--- a/src/generator/model.ts
+++ b/src/generator/model.ts
@@ -32,7 +32,7 @@ type MGModelField = {
 
 type MGModelOperationKeys = {
   name: string;
-  type: string;
+  types: DMMF.SchemaArgInputType[];
   required: boolean;
 };
 
@@ -161,11 +161,15 @@ export default class ModelGenerator
                           ${opK.name}
                         </td>
                         <td class="px-4 py-2 border">
-                        ${
-                          isScalarType(opK.type)
-                            ? opK.type
-                            : `<a href="#type-inputType-${opK.type}">${opK.type}</a>`
-                        }
+                        ${opK.types
+                          .map((t) =>
+                            isScalarType(t.type as string)
+                              ? t.type
+                              : `<a href="#type-inputType-${t.type}">${t.type}${
+                                  t.isList ? '[]' : ''
+                                }</a>`
+                          )
+                          .join(' | ')}
                         </td>
                         <td class="px-4 py-2 border">
                          ${opK.required ? '<b>Yes</b>' : 'No'} 
@@ -388,13 +392,13 @@ const ${singular} = await ${method}({
             ),
             opKeys: field?.args.map((a) => ({
               name: a.name,
-              type: a.inputType.type,
-              required: a.inputType.isRequired,
+              types: a.inputTypes,
+              required: a.isRequired,
             })),
             output: {
-              type: field?.outputType.type,
+              type: field?.outputType.type as string,
               kind: field?.outputType.kind,
-              required: field?.outputType.isRequired,
+              required: field?.isRequired,
               list: field?.outputType.isList,
             },
           });
@@ -420,13 +424,13 @@ const { count } = await ${method}({
             ),
             opKeys: field?.args.map((a) => ({
               name: a.name,
-              type: a.inputType.type,
-              required: a.inputType.isRequired,
+              types: a.inputTypes,
+              required: a.isRequired,
             })),
             output: {
-              type: field?.outputType.type,
+              type: field?.outputType.type as string,
               kind: field?.outputType.kind,
-              required: field?.outputType.isRequired,
+              required: field?.isRequired,
               list: field?.outputType.isList,
             },
           });
@@ -451,13 +455,13 @@ const ${singular} = await ${method}({
             ),
             opKeys: field?.args.map((a) => ({
               name: a.name,
-              type: a.inputType.type,
-              required: a.inputType.isRequired,
+              types: a.inputTypes,
+              required: a.isRequired,
             })),
             output: {
-              type: field?.outputType.type,
+              type: field?.outputType.type as string,
               kind: field?.outputType.kind,
-              required: field?.outputType.isRequired,
+              required: field?.isRequired,
               list: field?.outputType.isList,
             },
           });
@@ -481,13 +485,13 @@ const ${plural} = await ${method}({ take: 10 })
             ),
             opKeys: field?.args.map((a) => ({
               name: a.name,
-              type: a.inputType.type,
-              required: a.inputType.isRequired,
+              types: a.inputTypes,
+              required: a.isRequired,
             })),
             output: {
-              type: field?.outputType.type,
+              type: field?.outputType.type as string,
               kind: field?.outputType.kind,
-              required: field?.outputType.isRequired,
+              required: field?.isRequired,
               list: field?.outputType.isList,
             },
           });
@@ -513,13 +517,13 @@ const ${lowerCase(singular)} = await ${method}({
             ),
             opKeys: field?.args.map((a) => ({
               name: a.name,
-              type: a.inputType.type,
-              required: a.inputType.isRequired,
+              types: a.inputTypes,
+              required: a.isRequired,
             })),
             output: {
-              type: field?.outputType.type,
+              type: field?.outputType.type as string,
               kind: field?.outputType.kind,
-              required: field?.outputType.isRequired,
+              required: field?.isRequired,
               list: field?.outputType.isList,
             },
           });
@@ -549,13 +553,13 @@ const ${lowerCase(singular)} = await ${method}({
             ),
             opKeys: field?.args.map((a) => ({
               name: a.name,
-              type: a.inputType.type,
-              required: a.inputType.isRequired,
+              types: a.inputTypes,
+              required: a.isRequired,
             })),
             output: {
-              type: field?.outputType.type,
+              type: field?.outputType.type as string,
               kind: field?.outputType.kind,
-              required: field?.outputType.isRequired,
+              required: field?.isRequired,
               list: field?.outputType.isList,
             },
           });
@@ -583,13 +587,13 @@ const ${lowerCase(singular)} = await ${method}({
             ),
             opKeys: field?.args.map((a) => ({
               name: a.name,
-              type: a.inputType.type,
-              required: a.inputType.isRequired,
+              types: a.inputTypes,
+              required: a.isRequired,
             })),
             output: {
-              type: field?.outputType.type,
+              type: field?.outputType.type as string,
               kind: field?.outputType.kind,
-              required: field?.outputType.isRequired,
+              required: field?.isRequired,
               list: field?.outputType.isList,
             },
           });
@@ -620,13 +624,13 @@ const ${lowerCase(singular)} = await ${method}({
             ),
             opKeys: field?.args.map((a) => ({
               name: a.name,
-              type: a.inputType.type,
-              required: a.inputType.isRequired,
+              types: a.inputTypes,
+              required: a.isRequired,
             })),
             output: {
-              type: field?.outputType.type,
+              type: field?.outputType.type as string,
               kind: field?.outputType.kind,
-              required: field?.outputType.isRequired,
+              required: field?.isRequired,
               list: field?.outputType.isList,
             },
           });

--- a/src/tests/model.test.ts
+++ b/src/tests/model.test.ts
@@ -163,7 +163,15 @@ describe('model generator', () => {
           name: 'findOne',
           description: 'Find zero or one user',
           usage: 'Example usage',
-          opKeys: [{ name: 'where', required: false, type: 'UserWhereInput' }],
+          opKeys: [
+            {
+              name: 'where',
+              required: false,
+              types: [
+                { type: 'UserWhereInput', isList: false, kind: 'object' },
+              ],
+            },
+          ],
           output: { type: 'User', required: true, kind: 'object', list: false },
         },
         'User'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2019",
     "baseUrl": "src",
     "outDir": "dist",
+    "sourceMap": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "lib": ["es2019", "dom"], // dom is added for prismjs :(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,16 +2,6 @@
 # yarn lockfile v1
 
 
-"@apexearth/copy@^1.4.5":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@apexearth/copy/-/copy-1.4.5.tgz#966716249c831a168ef51eb224f53e0bb642ab79"
-  integrity sha512-Zws+jNVT54YUjBuNfDKje2uyoTQRYpIPMHDf6v6EI019ZqXnwYxb4/gZMlDjv+O+LnZbBn2Sc8DC5KAbcBNiaQ==
-  dependencies:
-    commander "^2.19.0"
-    mkdirp "^1.0.4"
-    prettysize "^2.0.0"
-    sleep-promise "^8.0.1"
-
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -467,17 +457,6 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@jest/types@^26.2.0":
-  version "26.2.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.2.0.tgz#b28ca1fb517a4eb48c0addea7fcd9edc4ab45721"
-  integrity sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/node" "*"
-    "@types/yargs" "^15.0.0"
-    chalk "^4.0.0"
-
 "@jest/types@^26.3.0":
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.3.0.tgz#97627bf4bdb72c55346eef98e3b3f7ddc4941f71"
@@ -515,33 +494,33 @@
   resolved "https://registry.yarnpkg.com/@prisma/ci-info/-/ci-info-2.1.2.tgz#3da64f54584bde0aaf4b42f298a6c63f025aeb3f"
   integrity sha512-RhAHY+wp6Nqu89Tp3zfUVkpGfqk4TfngeOWaMGgmhP7mB2ASDtOl8dkwxHmI8eN4edo+luyjPmbJBC4kST321A==
 
-"@prisma/cli@^2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.6.2.tgz#52fb447f702f159c9a218f720b0b809581815a0b"
-  integrity sha512-aDzA1kWwmfyt1FeTzayZ6fDc9uXRo+gt+KFsR9bNqHtdge2aZLA9N/ft9+1627HOADIQgfTFw41K0GOMBJQ48w==
+"@prisma/cli@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.8.0.tgz#919d7f66023affa76d14823212b62a8512cfd37d"
+  integrity sha512-Kg1C47d75jdEIMmJif8TMlv/2Ihx08E1qWp0euwoZhjd807HGnjgC9tJYjTfkdf+NMJSAUbvoPXKInEX0HoOMw==
 
-"@prisma/client@^2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.6.2.tgz#842c8640a0cd5b7542522ac0645f7c8c9bd87254"
-  integrity sha512-SYbW6+Lcd/OcY6p9vjI845ERl77Z+rOcB0zh6RKQdxr8R6yZHc7aDUnjcp8fZr245HnLLRnCpfkAfqQ3lvLP8g==
+"@prisma/client@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.8.0.tgz#a0f7247786c9b6ee804437acf8215854c5eb3946"
+  integrity sha512-5+GzRTkPnmv4OEV2tB8kwQt/xLLxBR/daJBcMt6pnnonJvrREsu0tSTdz2LJNPaj3kTT0fSS/OaeGMMdfVYSpw==
   dependencies:
     pkg-up "^3.1.0"
 
-"@prisma/debug@2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.6.2.tgz#2542896fef25d15ad3972dff516f6293693e9a00"
-  integrity sha512-FQroN5vk6nqm/8FAP4t29VfFF8Dmx/XT3Gm13fcOzJqlydHsKHEo2PpiNeRlXCnqmJqvz6x8DUr7e8CD9XdG5Q==
+"@prisma/debug@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.8.0.tgz#3a3cc367dd44e6696f786250d22adb9364b0e86c"
+  integrity sha512-mtHQMDQ2HBLY4Frz3S53O3KnX9ND+ow9KR/8tgiqGObVH6zmP25lNK0MQJcPe3KOQL8FO+PgYOccoWx31+1rvQ==
   dependencies:
     debug "^4.1.1"
 
-"@prisma/engine-core@2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.6.2.tgz#851dde890309ef959dd91b67a1d36a4f8486bacc"
-  integrity sha512-b3IhgBCJaeu6oUUcY8BPRHJC7xdFjDIQEdHxTzYcUTyYRdGzgZcVOQfQpfHdey+FpPJdyKPQOndopF8zun+cww==
+"@prisma/engine-core@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.8.0.tgz#f112c1ffc42d5c9eff304eb5035eaf119400e6ac"
+  integrity sha512-cgx39UIVwKU651qFDYK/WvIGegofpn5WmLD4JOAWeadQAvVTc+OXpkYbg23iCn9/if80cWk49pg5EM29S3jnZg==
   dependencies:
-    "@prisma/debug" "2.6.2"
-    "@prisma/generator-helper" "2.6.2"
-    "@prisma/get-platform" "2.6.2"
+    "@prisma/debug" "2.8.0"
+    "@prisma/generator-helper" "2.8.0"
+    "@prisma/get-platform" "2.8.0"
     chalk "^4.0.0"
     cross-fetch "^3.0.4"
     execa "^4.0.2"
@@ -550,15 +529,15 @@
     new-github-issue-url "^0.2.1"
     p-retry "^4.2.0"
     terminal-link "^2.1.1"
-    undici "git://github.com/nodejs/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744"
+    undici "2.0.5"
 
-"@prisma/fetch-engine@2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.6.2.tgz#f63de5e4d6247469fd67db360375204e0b95dc8a"
-  integrity sha512-ZzqFpMK4PGLNMs1Ez+KUF2G22hh+wTvdIn3eZmbb8prJZjQ0JgRm+3FF/5+VNx3QI2DSIAFVSea4ra+ZuQC53w==
+"@prisma/fetch-engine@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.8.0.tgz#a5102e513df43933d809dd5b0ce882ee7670db5d"
+  integrity sha512-yQtJS2kMzDol2VK87Tq5hluuf1/ZIg73LJYVMISgguOvRDiWtJ2KPJ7fhc+bFwYJf95+yD97G5kmx3lnpeXSSA==
   dependencies:
-    "@prisma/debug" "2.6.2"
-    "@prisma/get-platform" "2.6.2"
+    "@prisma/debug" "2.8.0"
+    "@prisma/get-platform" "2.8.0"
     chalk "^4.0.0"
     execa "^4.0.0"
     find-cache-dir "^3.3.1"
@@ -574,47 +553,48 @@
     progress "^2.0.3"
     rimraf "^3.0.2"
     temp-dir "^2.0.0"
-    tempy "^0.6.0"
+    tempy "^0.7.0"
 
-"@prisma/generator-helper@2.6.2", "@prisma/generator-helper@^2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.6.2.tgz#fc484254079461d32d831a13bcac9d9ff0736034"
-  integrity sha512-Q6Yc4JvYt4leL9/6UO139eVv4P6sjNFVhX1hBxK3Fp3tDgABZcZskrwW+gS1HjrVLdivBMtr8PnGoktR3eP++A==
+"@prisma/generator-helper@2.8.0", "@prisma/generator-helper@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.8.0.tgz#75b9f3d27299c7ad81897f37474f4b90b59494b9"
+  integrity sha512-eMBRP+hYM9HTX5Wn474Z6aT0S/JzmInTfxJ1TWJ8Z4jEgeCXfXcZU3oNKVdHAJ23kK7WMMBpuG+/EZMY2iLfhg==
   dependencies:
-    "@prisma/debug" "2.6.2"
+    "@prisma/debug" "2.8.0"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.6.2.tgz#aced41b5e33e90b0cb9fb80e9c0797c5ce5610b4"
-  integrity sha512-/k7Vl+kNCKhpDVZpK4/XX+G3b80FbhxE7qYEuYBUc09FPVN3t2P4mK1eWHUTK+cwngb9mnWuX2Z7gyQYJwRsKQ==
+"@prisma/get-platform@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.8.0.tgz#af24dbb1de8a3609025542e554b3dc8d11ded0ae"
+  integrity sha512-ygRsEFTrO6zNKp3kH7LVcmKu1Q4RQStgxOAxcHoVBWpSFFYY93DLS0gZvPwXuH5Oi5HHCOO5ZMfOflfZIR2/Cw==
   dependencies:
-    "@prisma/debug" "2.6.2"
+    "@prisma/debug" "2.8.0"
 
-"@prisma/sdk@^2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.6.2.tgz#6eb5ea7e7841908cacbc83b42c3f5cd4a669890e"
-  integrity sha512-sYeaC3o31aVf9u+uaBbVespLF7A6gGdylRtH5/9NbPoI1W52XpkiT45JQgvKIRuS6hlnLX6Um7w345Aebeo4NA==
+"@prisma/sdk@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.8.0.tgz#93ac3a56056f5467ef56b41ba21743c497fe9a84"
+  integrity sha512-20NNsDnPjCx5NJH5/iqfKjegCRXQpygFTpUSL3KF6WbfUiO3Uzvua+lme68TI8mTvQqZJaLFMm7mT5UBqUpeog==
   dependencies:
-    "@apexearth/copy" "^1.4.5"
-    "@prisma/debug" "2.6.2"
-    "@prisma/engine-core" "2.6.2"
-    "@prisma/fetch-engine" "2.6.2"
-    "@prisma/generator-helper" "2.6.2"
-    "@prisma/get-platform" "2.6.2"
+    "@prisma/debug" "2.8.0"
+    "@prisma/engine-core" "2.8.0"
+    "@prisma/fetch-engine" "2.8.0"
+    "@prisma/generator-helper" "2.8.0"
+    "@prisma/get-platform" "2.8.0"
+    "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^4.1.3"
     chalk "4.1.0"
-    checkpoint-client "1.1.11"
+    checkpoint-client "1.1.12"
     cli-truncate "^2.1.0"
+    dotenv "^8.2.0"
     execa "^4.0.0"
     global-dirs "^2.0.1"
     globby "^11.0.0"
     has-yarn "^2.1.0"
     make-dir "^3.0.2"
-    node-fetch "2.6.0"
+    node-fetch "2.6.1"
     p-map "^4.0.0"
     read-pkg-up "^7.0.1"
     resolve-pkg "^2.0.0"
@@ -625,7 +605,7 @@
     tar "^6.0.1"
     temp-dir "^2.0.0"
     temp-write "^4.0.0"
-    tempy "^0.6.0"
+    tempy "^0.7.0"
     terminal-link "^2.1.1"
     tmp "0.2.1"
     url-parse "^1.4.7"
@@ -643,6 +623,21 @@
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+"@timsuchanek/copy@^1.4.5":
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/@timsuchanek/copy/-/copy-1.4.5.tgz#8e9658c056e24e1928a88bed45f9eac6a72b7c40"
+  integrity sha512-N4+2/DvfwzQqHYL/scq07fv8yXbZc6RyUxKJoE8Clm14JpLOf9yNI4VB4D6RsV3h9zgzZ4loJUydHKM7pp3blw==
+  dependencies:
+    "@timsuchanek/sleep-promise" "^8.0.1"
+    commander "^2.19.0"
+    mkdirp "^1.0.4"
+    prettysize "^2.0.0"
+
+"@timsuchanek/sleep-promise@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@timsuchanek/sleep-promise/-/sleep-promise-8.0.1.tgz#81c0754b345138a519b51c2059771eb5f9b97818"
+  integrity sha512-cxHYbrXfnCWsklydIHSw5GCMHUPqpJ/enxWSyVHNOgNe61sit/+aOXTTI+VOdWkvVaJsI2vsB9N4+YDNITawOQ==
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -762,10 +757,18 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.x", "@types/jest@^26.0.13":
+"@types/jest@26.x":
   version "26.0.13"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.13.tgz#5a7b9d5312f5dd521a38329c38ee9d3802a0b85e"
   integrity sha512-sCzjKow4z9LILc6DhBvn5AkIfmQzDZkgtVVKmGwVrs5tuid38ws281D4l+7x1kP487+FlKDh5kfMZ8WSPAdmdA==
+  dependencies:
+    jest-diff "^25.2.1"
+    pretty-format "^25.2.1"
+
+"@types/jest@^26.0.14":
+  version "26.0.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.14.tgz#078695f8f65cb55c5a98450d65083b2b73e5a3f3"
+  integrity sha512-Hz5q8Vu0D288x3iWXePSn53W7hAjP0H7EQ6QvDO9c7t46mR0lNOLlfuwQ+JkVxuhygHzlzPX+0jKdA3ZgSh+Vg==
   dependencies:
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
@@ -785,10 +788,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.22.tgz#23ea4d88189cec7d58f9e6b66f786b215eb61bdc"
   integrity sha512-emeGcJvdiZ4Z3ohbmw93E/64jRzUHAItSHt8nF7M4TGgQTiWqFVGB8KNpLGFmUHmHLvjvBgFwVlqNcq+VuGv9g==
 
-"@types/node@^14.10.1":
-  version "14.10.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.10.1.tgz#cc323bad8e8a533d4822f45ce4e5326f36e42177"
-  integrity sha512-aYNbO+FZ/3KGeQCEkNhHFRIzBOUgc7QvcVNKXbfnhDkSfwUv91JsQQa10rDgKSTSLkXZ1UIyPe4FJJNVgw1xWQ==
+"@types/node@^14.11.2":
+  version "14.11.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.2.tgz#2de1ed6670439387da1c9f549a2ade2b0a799256"
+  integrity sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1336,10 +1339,10 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-checkpoint-client@1.1.11:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.11.tgz#992818640b9ef12d66304bf973d993760b1e6926"
-  integrity sha512-p+eDmbuKlP6oHgknetUoqWTHnQsWfSbDlaMlKgwNh8RiEdLQVZ5z1rcU4+0iBynZe2z8sJHHSdWo9VQTmGWRLw==
+checkpoint-client@1.1.12:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.12.tgz#406fb898a95c2911235aa3e3bf4564de66cb6d8d"
+  integrity sha512-YbQMJe28YfLWBst/YvQhrh12afZGy67J7Uo/q9U0OfrFXZq3D8OyDPgjZkc+zRRK3wppC28SiCQ0fbgalsmCqA==
   dependencies:
     "@prisma/ci-info" "2.1.2"
     cross-spawn "7.0.3"
@@ -1347,8 +1350,8 @@ checkpoint-client@1.1.11:
     fast-write-atomic "0.2.1"
     make-dir "3.1.0"
     ms "2.1.2"
-    node-fetch "2.6.0"
-    uuid "8.1.0"
+    node-fetch "2.6.1"
+    uuid "8.3.0"
 
 chownr@^2.0.0:
   version "2.0.0"
@@ -1668,6 +1671,20 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+del@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-6.0.0.tgz#0b40d0332cea743f1614f818be4feb717714c952"
+  integrity sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==
+  dependencies:
+    globby "^11.0.1"
+    graceful-fs "^4.2.4"
+    is-glob "^4.0.1"
+    is-path-cwd "^2.2.0"
+    is-path-inside "^3.0.2"
+    p-map "^4.0.0"
+    rimraf "^3.0.2"
+    slash "^3.0.0"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -1721,6 +1738,11 @@ domexception@^2.0.1:
   integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
   dependencies:
     webidl-conversions "^5.0.0"
+
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -2194,7 +2216,7 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-globby@^11.0.0:
+globby@^11.0.0, globby@^11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
   integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
@@ -2546,6 +2568,16 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-path-cwd@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
+  integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
+
+is-path-inside@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
+  integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
 
 is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -2989,19 +3021,7 @@ jest-snapshot@^26.4.2:
     pretty-format "^26.4.2"
     semver "^7.3.2"
 
-jest-util@26.x:
-  version "26.2.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.2.0.tgz#0597d2a27c559340957609f106c408c17c1d88ac"
-  integrity sha512-YmDwJxLZ1kFxpxPfhSJ0rIkiZOM0PQbRcfH0TzJOhqCisCAsI1WcmoQqO83My9xeVA2k4n+rzg2UuexVKzPpig==
-  dependencies:
-    "@jest/types" "^26.2.0"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    is-ci "^2.0.0"
-    micromatch "^4.0.2"
-
-jest-util@^26.3.0:
+jest-util@^26.1.0, jest-util@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.3.0.tgz#a8974b191df30e2bf523ebbfdbaeb8efca535b3e"
   integrity sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==
@@ -3177,10 +3197,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-kleur@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.1.tgz#80b49dd7d1afeba41b8dcdf4ecfff9252205fc52"
-  integrity sha512-BsNhM6T/yTWFG580CRnYhT3LfUuPK7Hwrm+W2H0G8lK/nogalP5Nsrh/cHjxVVkzl0sFm7z8b8rNcZCfKxeoxA==
+kleur@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.3.tgz#8d262a56d79a137ee1b706e967c0b08a7fef4f4c"
+  integrity sha512-H1tr8QP2PxFTNwAFM74Mui2b6ovcY9FoxJefgrwxY+OCJcq01k5nvhf4M/KnizzrJvLRap5STUy7dgDV35iUBw==
 
 lazystream@^1.0.0:
   version "1.0.0"
@@ -3505,6 +3525,11 @@ node-fetch@2.6.0, node-fetch@^2.6.0:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -3818,10 +3843,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.1.tgz#d9485dd5e499daa6cb547023b87a6cf51bee37d6"
-  integrity sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==
+prettier@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
+  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"
@@ -4288,11 +4313,6 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-sleep-promise@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/sleep-promise/-/sleep-promise-8.0.1.tgz#8d795a27ea23953df6b52b91081e5e22665993c5"
-  integrity sha1-jXlaJ+ojlT32tSuRCB5eImZZk8U=
-
 slice-ansi@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
@@ -4580,11 +4600,12 @@ temp-write@^4.0.0:
     temp-dir "^1.0.0"
     uuid "^3.3.2"
 
-tempy@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.6.0.tgz#65e2c35abc06f1124a97f387b08303442bde59f3"
-  integrity sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==
+tempy@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.7.1.tgz#5a654e6dbd1747cdd561efb112350b55cd9c1d46"
+  integrity sha512-vXPxwOyaNVi9nyczO16mxmHGpl6ASC5/TVhRRHpqeYHvKQm58EaWNvZXxAhR0lYYnBOQFjXjhzeLsaXdjxLjRg==
   dependencies:
+    del "^6.0.0"
     is-stream "^2.0.0"
     temp-dir "^2.0.0"
     type-fest "^0.16.0"
@@ -4700,22 +4721,22 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
   integrity sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
 
-ts-jest@^26.3.0:
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.3.0.tgz#6b2845045347dce394f069bb59358253bc1338a9"
-  integrity sha512-Jq2uKfx6bPd9+JDpZNMBJMdMQUC3sJ08acISj8NXlVgR2d5OqslEHOR2KHMgwymu8h50+lKIm0m0xj/ioYdW2Q==
+ts-jest@^26.4.1:
+  version "26.4.1"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.1.tgz#08ec0d3fc2c3a39e4a46eae5610b69fafa6babd0"
+  integrity sha512-F4aFq01aS6mnAAa0DljNmKr/Kk9y4HVZ1m6/rtJ0ED56cuxINGq3Q9eVAh+z5vcYKe5qnTMvv90vE8vUMFxomg==
   dependencies:
     "@types/jest" "26.x"
     bs-logger "0.x"
     buffer-from "1.x"
     fast-json-stable-stringify "2.x"
-    jest-util "26.x"
+    jest-util "^26.1.0"
     json5 "2.x"
     lodash.memoize "4.x"
     make-error "1.x"
     mkdirp "1.x"
     semver "7.x"
-    yargs-parser "18.x"
+    yargs-parser "20.x"
 
 ts-node@^9.0.0:
   version "9.0.0"
@@ -4792,14 +4813,15 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
-  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
+typescript@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
-"undici@git://github.com/nodejs/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744":
-  version "1.3.1"
-  resolved "git://github.com/nodejs/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744"
+undici@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-2.0.5.tgz#b604e203184002d2ecf6524581ac994346700a09"
+  integrity sha512-KluDT7X78oGS+/3bxwGE06e/4x4wbuK7TNmTMLPJNmEOkzrLGBMwAnWMxm3PukR9BnB7k20IzOpGjl90AltwFQ==
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -4866,20 +4888,15 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
-  integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
+uuid@8.3.0, uuid@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
+  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
 uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
-  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
 v8-to-istanbul@^5.0.1:
   version "5.0.1"
@@ -5037,7 +5054,12 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@18.x, yargs-parser@^18.1.2, yargs-parser@^18.1.3:
+yargs-parser@20.x:
+  version "20.2.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.1.tgz#28f3773c546cdd8a69ddae68116b48a5da328e77"
+  integrity sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA==
+
+yargs-parser@^18.1.2, yargs-parser@^18.1.3:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==


### PR DESCRIPTION
Fixes: https://github.com/pantharshit00/prisma-docs-generator/issues/16

Prisma version `2.8.0` introduced input union types on the dmmf level which improves the protocol between the client and engine. This is not a user facing feature but this breaks existing generators which depends on the older behaviour.

This PR fixes it for `prisma-docs-generator`