### PR TITLE
fix: drop <b> tag in favour of <strong>

### DIFF
--- a/src/generator/model.ts
+++ b/src/generator/model.ts
@@ -117,7 +117,7 @@ export default class ModelGenerator
         </ul>
       </td>
       <td class="px-4 py-2 border">
-        ${field.required ? `<b>Yes</b>` : 'No'}
+        ${field.required ? `<strong>Yes</strong>` : 'No'}
       </td>
       <td class="px-4 py-2 border">
         ${field.documentation ?? '-'}
@@ -172,7 +172,7 @@ export default class ModelGenerator
                           .join(' | ')}
                         </td>
                         <td class="px-4 py-2 border">
-                         ${opK.required ? '<b>Yes</b>' : 'No'} 
+                         ${opK.required ? '<strong>Yes</strong>' : 'No'} 
                         </td>
                       </tr>
                       `

--- a/src/tests/__snapshots__/model.test.ts.snap
+++ b/src/tests/__snapshots__/model.test.ts.snap
@@ -54,7 +54,7 @@ exports[`model generator renders model field table row correctly 2`] = `
         </ul>
       </td>
       <td class=\\"px-4 py-2 border\\">
-        <b>Yes</b>
+        <strong>Yes</strong>
       </td>
       <td class=\\"px-4 py-2 border\\">
         This is some docs

--- a/styles_generator/index.html
+++ b/styles_generator/index.html
@@ -119,7 +119,7 @@
         </ul>
       </td>
       <td class="px-4 py-2 border">
-        <b>Yes</b>
+        <strong>Yes</strong>
       </td>
       <td class="px-4 py-2 border">
         -
@@ -139,7 +139,7 @@
         </ul>
       </td>
       <td class="px-4 py-2 border">
-        <b>Yes</b>
+        <strong>Yes</strong>
       </td>
       <td class="px-4 py-2 border">
         -
@@ -159,7 +159,7 @@
         </ul>
       </td>
       <td class="px-4 py-2 border">
-        <b>Yes</b>
+        <strong>Yes</strong>
       </td>
       <td class="px-4 py-2 border">
         -
@@ -199,7 +199,7 @@
         </ul>
       </td>
       <td class="px-4 py-2 border">
-        <b>Yes</b>
+        <strong>Yes</strong>
       </td>
       <td class="px-4 py-2 border">
         -
@@ -247,7 +247,7 @@
                           PostWhereUniqueInput
                         </td>
                         <td class="px-4 py-2 border">
-                         <b>Yes</b> 
+                         <strong>Yes</strong> 
                         </td>
                       </tr>
                       
@@ -373,7 +373,7 @@
                           PostCreateInput
                         </td>
                         <td class="px-4 py-2 border">
-                         <b>Yes</b> 
+                         <strong>Yes</strong> 
                         </td>
                       </tr>
                       
@@ -412,7 +412,7 @@
                           PostWhereUniqueInput
                         </td>
                         <td class="px-4 py-2 border">
-                         <b>Yes</b> 
+                         <strong>Yes</strong> 
                         </td>
                       </tr>
                       
@@ -455,7 +455,7 @@
                           PostUpdateInput
                         </td>
                         <td class="px-4 py-2 border">
-                         <b>Yes</b> 
+                         <strong>Yes</strong> 
                         </td>
                       </tr>
                       
@@ -467,7 +467,7 @@
                           PostWhereUniqueInput
                         </td>
                         <td class="px-4 py-2 border">
-                         <b>Yes</b> 
+                         <strong>Yes</strong> 
                         </td>
                       </tr>
                       
@@ -548,7 +548,7 @@
                           PostUpdateManyMutationInput
                         </td>
                         <td class="px-4 py-2 border">
-                         <b>Yes</b> 
+                         <strong>Yes</strong> 
                         </td>
                       </tr>
                       
@@ -605,7 +605,7 @@
                           PostWhereUniqueInput
                         </td>
                         <td class="px-4 py-2 border">
-                         <b>Yes</b> 
+                         <strong>Yes</strong> 
                         </td>
                       </tr>
                       
@@ -617,7 +617,7 @@
                           PostCreateInput
                         </td>
                         <td class="px-4 py-2 border">
-                         <b>Yes</b> 
+                         <strong>Yes</strong> 
                         </td>
                       </tr>
                       
@@ -629,7 +629,7 @@
                           PostUpdateInput
                         </td>
                         <td class="px-4 py-2 border">
-                         <b>Yes</b> 
+                         <strong>Yes</strong> 
                         </td>
                       </tr>
                       


### PR DESCRIPTION
To avoid a semantic html problem, the `<b>` tag should be replaced with the `<strong>` tag, according to sonarqube and best practices.

<img width="1049" alt="image" src="https://user-images.githubusercontent.com/4494526/154551403-69a9e026-94d6-4365-a257-196d2da78947.png">

https://developer.mozilla.org/es/docs/Web/HTML/Element/strong