### PR TITLE
Add flex-shrink: 0 to the side menu

### DIFF
--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -62,7 +62,7 @@ export default class HTMLPrinter implements Generatable<DMMFDocument> {
   <body class="bg-gray-200">
     <div class="flex min-h-screen">
       <div
-        class="sticky top-0 w-1/5 h-screen p-4 px-6 mr-4 overflow-auto bg-white mac-h-screen"
+        class="sticky top-0 w-1/5 flex-shrink-0 h-screen p-4 px-6 mr-4 overflow-auto bg-white mac-h-screen"
       >
         <div class="mb-8">
           ${this.getPrismaSvg()}

--- a/styles_generator/index.html
+++ b/styles_generator/index.html
@@ -12,7 +12,7 @@
   <body class="bg-gray-200">
     <div class="flex min-h-screen">
       <div
-        class="sticky top-0 w-1/5 h-screen p-4 px-6 mr-4 overflow-auto bg-white mac-h-screen"
+        class="sticky top-0 w-1/5 shrink-0 h-screen p-4 px-6 mr-4 overflow-auto bg-white mac-h-screen"
       >
         <div class="mb-8">
           

--- a/styles_generator/index.html
+++ b/styles_generator/index.html
@@ -12,7 +12,7 @@
   <body class="bg-gray-200">
     <div class="flex min-h-screen">
       <div
-        class="sticky top-0 w-1/5 shrink-0 h-screen p-4 px-6 mr-4 overflow-auto bg-white mac-h-screen"
+        class="sticky top-0 w-1/5 flex-shrink-0 h-screen p-4 px-6 mr-4 overflow-auto bg-white mac-h-screen"
       >
         <div class="mb-8">
           


### PR DESCRIPTION
If main contents becomes wider, there is a change that the side menu is almost 0 width.
Add `flex-shrink: 0` into side menu to keep always 20% width.

https://v2.tailwindcss.com/docs/flex-shrink

![スクリーンショット 2023-02-06 16 02 59](https://user-images.githubusercontent.com/856469/216905798-aca2fc8f-90b7-4f40-8d81-de213b2a99f7.png)
