### PR TITLE
Add new option `includeRelationFields`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ generator docs {
 }
 ```
 
+### includeRelationFields
+
+You can specify whether relation fields are shown or not.
+Default value is `true`.
+
+```prisma
+generator docs {
+  provider = "node node_modules/prisma-docs-generator"
+  includeRelationFields = false
+}
+```
+
 ## CLI
 
 This package also ships with a CLI which is used to serve the docs right now. It has the following subcommands:

--- a/src/generator/transformDMMF.ts
+++ b/src/generator/transformDMMF.ts
@@ -21,9 +21,23 @@ export type DMMFDocument = Omit<ExternalDMMF.Document, 'mappings'> & {
   mappings: DMMFMapping[];
 };
 
+type OptionsForTransformDMMF = {
+  includeRelationFields: boolean
+}
+
 export default function transformDMMF(
-  dmmf: ExternalDMMF.Document
+  dmmf: ExternalDMMF.Document,
+  { includeRelationFields }: OptionsForTransformDMMF
 ): DMMFDocument {
+  if (!includeRelationFields) {
+    dmmf.datamodel.models = dmmf.datamodel.models.map(model => {
+      model.fields = model.fields.filter(
+        field => !field.relationName
+      );
+      return model;
+    });
+  }
+
   return {
     ...dmmf,
     mappings: getMappings(dmmf.mappings, dmmf.datamodel),

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,12 @@ generatorHandler({
     };
   },
   async onGenerate(options) {
-    const dmmf = transformDMMF(options.dmmf);
+    const { config } = options.generator;
+    const includeRelationFields = config.includeRelationFields === 'false' ? false : true;
+
+    const dmmf = transformDMMF(options.dmmf, {
+      includeRelationFields,
+    });
     const html = new HTMLPrinter(dmmf);
 
     const output = options.generator.output?.value;

--- a/src/tests/model.test.ts
+++ b/src/tests/model.test.ts
@@ -16,7 +16,9 @@ describe('model generator', () => {
     `;
 
     const dmmf = await getDMMF({ datamodel: datamodelString });
-    const transformedDmmf = transformDMMF(dmmf);
+    const transformedDmmf = transformDMMF(dmmf, {
+      includeRelationFields: true,
+    });
 
     const modelGen = new ModelGenerator(transformedDmmf);
     const spy = jest.spyOn(modelGen, 'getModelDiretiveHTML');
@@ -61,7 +63,9 @@ describe('model generator', () => {
     `;
 
     const dmmf = await getDMMF({ datamodel: datamodelString });
-    const transformedDmmf = transformDMMF(dmmf);
+    const transformedDmmf = transformDMMF(dmmf, {
+      includeRelationFields: true,
+    });
 
     const modelGen = new ModelGenerator(transformedDmmf);
     const spy = jest.spyOn(modelGen, 'getModelFieldTableRow');
@@ -150,7 +154,9 @@ describe('model generator', () => {
     `;
 
     const dmmf = await getDMMF({ datamodel: datamodelString });
-    const transformedDmmf = transformDMMF(dmmf);
+    const transformedDmmf = transformDMMF(dmmf, {
+      includeRelationFields: true,
+    });
 
     const modelGen = new ModelGenerator(transformedDmmf);
     const spy = jest.spyOn(modelGen, 'getModelOperationMarkup');

--- a/src/tests/toc.test.ts
+++ b/src/tests/toc.test.ts
@@ -18,7 +18,9 @@ const datamodel = /* Prisma */ `
 describe('TOC', () => {
   it('renders TOC Subheader correctly', async () => {
     const dmmf = await getDMMF({ datamodel });
-    const toc = new TOCGenerator(transformDMMF(dmmf));
+    const toc = new TOCGenerator(transformDMMF(dmmf, {
+      includeRelationFields: true,
+    }));
     const spy = jest.spyOn(toc, 'getTOCSubHeaderHTML');
     // trigger the function
     toc.toHTML();
@@ -30,7 +32,9 @@ describe('TOC', () => {
 
   it('renders TOC subfield correctly', async () => {
     const dmmf = await getDMMF({ datamodel });
-    const toc = new TOCGenerator(transformDMMF(dmmf));
+    const toc = new TOCGenerator(transformDMMF(dmmf, {
+      includeRelationFields: true,
+    }));
 
     const spy = jest.spyOn(toc, 'getSubFieldHTML');
     toc.toHTML();
@@ -50,7 +54,9 @@ describe('TOC', () => {
 
   it('renders on toHTML', async () => {
     const dmmf = await getDMMF({ datamodel });
-    const toc = new TOCGenerator(transformDMMF(dmmf));
+    const toc = new TOCGenerator(transformDMMF(dmmf, {
+      includeRelationFields: true,
+    }));
 
     const subheaderSpy = jest.spyOn(toc, 'getTOCSubHeaderHTML');
     const subfieldSpy = jest.spyOn(toc, 'getSubFieldHTML');

--- a/src/tests/transformDMMF.test.ts
+++ b/src/tests/transformDMMF.test.ts
@@ -1,0 +1,99 @@
+import transformDMMF from '../generator/transformDMMF';
+//@ts-ignore
+import { getDMMF } from '@prisma/sdk';
+
+describe('transformDMMF', () => {
+  it('show relation fields when includeRelationFields = true', async () => {
+    const datamodelString = /* Prisma */ `
+      model User {
+        id String @default(cuid()) @id
+        name String
+        otherField Int
+        posts Post[]
+      }
+
+      model Post {
+        id String @id @default(cuid())
+        title String?
+        userId String
+        user User @relation(fields:[userId], references:[id])
+      }
+    `;
+
+    const dmmf = await getDMMF({ datamodel: datamodelString });
+    const transformedDmmf = transformDMMF(dmmf, {
+      includeRelationFields: true,
+    });
+
+    expect(transformedDmmf).toMatchObject({
+      datamodel: {
+        models: [
+          {
+            name: 'User',
+            fields: [
+              { name: 'id' },
+              { name: 'name' },
+              { name: 'otherField' },
+              { name: 'posts' },
+            ],
+          },
+          {
+            name: 'Post',
+            fields: [
+              { name: 'id' },
+              { name: 'title' },
+              { name: 'userId' },
+              { name: 'user' },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it('hide relation fields when includeRelationFields = false', async () => {
+    const datamodelString = /* Prisma */ `
+      model User {
+        id String @default(cuid()) @id
+        name String
+        otherField Int
+        posts Post[]
+      }
+
+      model Post {
+        id String @id @default(cuid())
+        title String?
+        userId String
+        user User @relation(fields:[userId], references:[id])
+      }
+    `;
+
+    const dmmf = await getDMMF({ datamodel: datamodelString });
+    const transformedDmmf = transformDMMF(dmmf, {
+      includeRelationFields: false,
+    });
+
+    expect(transformedDmmf).toMatchObject({
+      datamodel: {
+        models: [
+          {
+            name: 'User',
+            fields: [
+              { name: 'id' },
+              { name: 'name' },
+              { name: 'otherField' },
+            ],
+          },
+          {
+            name: 'Post',
+            fields: [
+              { name: 'id' },
+              { name: 'title' },
+              { name: 'userId' },
+            ],
+          },
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
Add option for `includeRelationFields` like other generator.
I followed this code.
https://github.com/notiz-dev/prisma-dbml-generator/blob/6b4b323400b3c5154ba0c85de6e0f68b271a2def/src/generator/table.ts#L76-L78


<table><tr><th>includeRelationFields = true(default)</th><th>includeRelationFields = false</th></tr>
<tr><td>

![スクリーンショット 2023-02-06 19 37 49](https://user-images.githubusercontent.com/856469/216950705-d3a687cf-86b7-4ab8-b6e6-ef0efd0ea987.png)

</td><td>

![スクリーンショット 2023-02-06 19 37 24](https://user-images.githubusercontent.com/856469/216950732-e6c6af51-35e7-40c1-a8fe-928b479cd453.png)

</td></tr>
</table>
