### PR TITLE
fix: prevent overflow with long property names

### DIFF
--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -69,7 +69,7 @@ export default class HTMLPrinter implements Generatable<DMMFDocument> {
         </div>
         ${tocGen.toHTML()}
       </div>
-      <div class="w-full p-4 bg-white">
+      <div class="w-full p-4 bg-white overflow-x-hidden">
         ${modelGen.toHTML()}
         ${typeGen.toHTML()}
       </div>


### PR DESCRIPTION
Before:
![image](https://github.com/pantharshit00/prisma-docs-generator/assets/63687573/36dfa369-465e-4573-9dd1-ad532ec9ef79)

After:
![image](https://github.com/pantharshit00/prisma-docs-generator/assets/63687573/2fa4073b-3d7c-48b2-9e09-65004a71b0ef)
